### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/iyaki/iyaki.github.io/security/code-scanning/3](https://github.com/iyaki/iyaki.github.io/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks, the minimal required permission is `contents: read`. This ensures the `GITHUB_TOKEN` has only the necessary access to the repository contents and avoids granting unnecessary write permissions.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added specifically to the `build` job if other jobs in the workflow require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
